### PR TITLE
make time forward and backward functions aware of the prefix value

### DIFF
--- a/time-zones.el
+++ b/time-zones.el
@@ -85,32 +85,32 @@ Uses `completing-read' for selection."
   (time-zones--start-timer)
   (time-zones--refresh-display))
 
-(defun time-zones-time-forward ()
-  "Move time forward by 15 minutes and stop auto-refresh."
-  (interactive)
+(defun time-zones-time-forward (arg)
+  "Move time forward by 15 minutes per ARG (default 1) and stop auto-refresh."
+  (interactive "p")
   (time-zones--stop-timer)
-  (setq time-zones--time-offset (+ time-zones--time-offset (* 15 60)))
+  (setq time-zones--time-offset (+ time-zones--time-offset (* 15 60 arg)))
   (time-zones--refresh-display))
 
-(defun time-zones-time-backward ()
-  "Move time backward by 15 minutes and stop auto-refresh."
-  (interactive)
+(defun time-zones-time-backward (arg)
+  "Move time backward by 15 minutes per ARG (default 1) and stop auto-refresh."
+  (interactive "p")
   (time-zones--stop-timer)
-  (setq time-zones--time-offset (- time-zones--time-offset (* 15 60)))
+  (setq time-zones--time-offset (- time-zones--time-offset (* 15 60 arg)))
   (time-zones--refresh-display))
 
-(defun time-zones-time-forward-hour ()
-  "Move time forward by 1 hour and stop auto-refresh."
-  (interactive)
+(defun time-zones-time-forward-hour (arg)
+  "Move time forward by 1 hour per ARG (default 1) and stop auto-refresh."
+  (interactive "p")
   (time-zones--stop-timer)
-  (setq time-zones--time-offset (+ time-zones--time-offset (* 60 60)))
+  (setq time-zones--time-offset (+ time-zones--time-offset (* 60 60 arg)))
   (time-zones--refresh-display))
 
-(defun time-zones-time-backward-hour ()
-  "Move time backward by 1 hour and stop auto-refresh."
-  (interactive)
+(defun time-zones-time-backward-hour (arg)
+  "Move time backward by 1 hour per ARG (default 1) and stop auto-refresh."
+  (interactive "p")
   (time-zones--stop-timer)
-  (setq time-zones--time-offset (- time-zones--time-offset (* 60 60)))
+  (setq time-zones--time-offset (- time-zones--time-offset (* 60 60 arg)))
   (time-zones--refresh-display))
 
 (defvar time-zones--timezones-url


### PR DESCRIPTION
Allow the usage of the prefix key and a numerical value to execute the forward or backward move by x times.
e.g. `C-u 24 M-x time-zones-time-forward-hour` will forward the clock by 24 hours.